### PR TITLE
Fix default values for component

### DIFF
--- a/src/JinnToast.js
+++ b/src/JinnToast.js
@@ -45,14 +45,14 @@ export class JinnToast extends HTMLElement {
     this.close = (this._initVar('close', false)) === 'true';
     this.destination = this._initVar('destination', undefined);
     this.duration = Number(this._initVar('duration', 3000));
-    this.escapeMarkup = (this._initVar('escapeMarkup', true)) === 'true';
+    this.escapeMarkup = (this._initVar('escapeMarkup', 'true')) === 'true';
     this.gravity = this._initVar('gravity', 'top');
-    this.newWindow = (this._initVar('newWindow', false)) === 'true';
+    this.newWindow = (this._initVar('newWindow', 'false')) === 'true';
     this.offSet = this._initVar('offSet', {});
-    this.oldestFirst = (this._initVar('oldestFirst', true)) === 'true';
+    this.oldestFirst = (this._initVar('oldestFirst', 'true')) === 'true';
     this.position = this._initVar('position', 'right');
     // this.selector = this._initVar('selector','');
-    this.stopOnFocus = this._initVar('stopOnFocus', true);
+    this.stopOnFocus = (this._initVar('stopOnFocus', 'true')) === 'true';
     this.text = this._initVar('text', '');
 
     const style = `


### PR DESCRIPTION
The `escapeMarkup` opens jinn-toast up for a script injection attack. If escapeMarkup attribute is not passed, it will default to the boolean true, which is _not_ equal to the string 'true'. Causing it to be false and the text to eventually be set as `innerHtml`. So setting the text to anything HTML (like a script tag) opens a vector for script injection.